### PR TITLE
[HOPSWORKS-CLOUD-2122] Add command-failed to cluster error states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ BUG FIXES:
 * resource/hopsworksai_cluster: Fix validation condition for `backup_retention_period`
 * datasource/hopsworksai_cluster: Check if cluster is not nil before updating state
 * resource/hopsworksai_cluster: Set Required to true for `aws_attributes/network/subnet_id` to ensure setting the subnet_name if setting up your own network configuration
+* Add command-failed to cluster error states
 
 ENHANCEMENTS:
 * resource/hopsworksai_cluster: Add a new attribute `init_script`

--- a/hopsworksai/internal/api/model.go
+++ b/hopsworksai/internal/api/model.go
@@ -36,6 +36,7 @@ const (
 	Decommissioning    ClusterState = "decommissioning"
 	RonDBInitializing  ClusterState = "rondb-initializing"
 	StartingHopsworks  ClusterState = "starting-hopsworks"
+	CommandFailed      ClusterState = "command-failed"
 	// Worker states
 	WorkerPending         ClusterState = worker + "-" + Pending
 	WorkerInitializing    ClusterState = worker + "-" + Initializing

--- a/hopsworksai/resource_cluster.go
+++ b/hopsworksai/resource_cluster.go
@@ -1280,6 +1280,7 @@ func resourceClusterWaitForRunning(ctx context.Context, client *api.HopsworksAIC
 			api.Running,
 			api.Error,
 			api.WorkerError,
+			api.CommandFailed,
 		},
 		timeout,
 		func() (result interface{}, state string, err error) {
@@ -1354,6 +1355,7 @@ func resourceClusterWaitForDeleting(ctx context.Context, client *api.HopsworksAI
 			api.Error,
 			api.ClusterDeleted,
 			api.TerminationWarning,
+			api.CommandFailed,
 		},
 		timeout,
 		func() (result interface{}, state string, err error) {


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
  - [ ] Adds tests for the submitted changes (for bug fixes & features)
  - [ ] Passes the tests including acceptance test
  - [x] An issue has been opened for this PR
  - [x] Updates the change log
  - [x] All commits have been squashed down to a single commit


* **Close the associated issue**
  
  Closes https://github.com/logicalclocks/hopsworks-cloud/issues/2122
  