### PR TITLE
Fix TestExpandTags to handle outputs with no order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ BREAKING CHANGES:
 
 BUG FIXES:
 * resource/hopsworksai_cluster: The `version` updates should always run with no other updates.
+* Fix TestExpandTags to avoid inconsistent results due to different ordering when iterating the tags map.
 
 ENHANCEMENTS:
 * resource/hopsworksai_cluster: Add support for updating `version` attribute to allow upgrade and rollback

--- a/hopsworksai/internal/structure/cluster_test.go
+++ b/hopsworksai/internal/structure/cluster_test.go
@@ -1162,7 +1162,7 @@ func TestExpandTags(t *testing.T) {
 		"tag2": "tag2-value",
 	}
 
-	expected := []api.ClusterTag{
+	expected1 := []api.ClusterTag{
 		{
 			Name:  "tag1",
 			Value: "tag1-value",
@@ -1173,9 +1173,20 @@ func TestExpandTags(t *testing.T) {
 		},
 	}
 
+	expected2 := []api.ClusterTag{
+		{
+			Name:  "tag2",
+			Value: "tag2-value",
+		},
+		{
+			Name:  "tag1",
+			Value: "tag1-value",
+		},
+	}
+
 	output := ExpandTags(input)
-	if !reflect.DeepEqual(expected, output) {
-		t.Fatalf("error while matching:\nexpected %#v \nbut got %#v", expected, output)
+	if !(reflect.DeepEqual(expected1, output) || reflect.DeepEqual(expected2, output)) {
+		t.Fatalf("error while matching:\nexpected %#v or %#v \nbut got %#v", expected1, expected2, output)
 	}
 }
 

--- a/test-fixtures/run-acceptance-tests.sh
+++ b/test-fixtures/run-acceptance-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e 
 ACCTEST_TIMEOUT=${ACCTEST_TIMEOUT:-240m}
 ACCTEST_PARALLELISM=${ACCTEST_PARALLELISM:-2}


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
  - [ ] Adds tests for the submitted changes (for bug fixes & features)
  - [] Passes the tests including acceptance test
  - [x] An issue has been opened for this PR
  - [x] Updates the change log
  - [x] All commits have been squashed down to a single commit


* **Close the associated issue**
  
  Closes https://github.com/logicalclocks/terraform-provider-hopsworksai/issues/37
