### PR TITLE
Deprecate enable_upgrade for aws_instance_profile and azure_user_assigned_identity_permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 ## 0.8.0 (Unreleased)
 
+NOTES:
+
+* datasource/aws_instance_profile_policy: Deprecate `enable_upgrade` attribute since these permissions are not required anymore from version 2.4.0 onwards
+* datasource/azure_user_assigned_identity_permissions: Deprecate `enable_upgrade` attribute since these permissions are not required anymore from version 2.4.0 onwards
+
 BREAKING CHANGES:
 
 BUG FIXES:
 * resource/hopsworksai_cluster: fix incorrect conversion error
 
 ENHANCEMENTS:
+* datasource/aws_instance_profile_policy: Set Default to false for `enable_upgrade` attribute 
 
 FEATURES:
 

--- a/docs/data-sources/aws_instance_profile_policy.md
+++ b/docs/data-sources/aws_instance_profile_policy.md
@@ -41,7 +41,7 @@ data "hopsworksai_aws_instance_profile_policy" "policy" {
 - **enable_cloud_watch** (Boolean) Add permissions required to allow collecting your cluster logs using cloud watch. Defaults to `true`.
 - **enable_eks_and_ecr** (Boolean) Add permissions required to enable access to Amazon EKS and ECR from within your Hopsworks cluster. Defaults to `true`.
 - **enable_storage** (Boolean) Add permissions required to allow Hopsworks clusters to read and write from and to your aws S3 buckets. Defaults to `true`.
-- **enable_upgrade** (Boolean) Add permissions required to enable upgrade to newer versions of Hopsworks. Defaults to `true`.
+- **enable_upgrade** (Boolean, Deprecated) Add permissions required to enable upgrade to newer versions of Hopsworks. Defaults to `false`. These permissions are not required anymore to upgrade from version 2.4.0 and onwards.
 - **id** (String) The ID of this resource.
 
 ### Read-Only

--- a/docs/data-sources/azure_user_assigned_identity_permissions.md
+++ b/docs/data-sources/azure_user_assigned_identity_permissions.md
@@ -32,7 +32,7 @@ data "hopsworksai_azure_user_assigned_identity_permissions" "permissions" {
 - **enable_aks_and_acr** (Boolean) Add permissions required to enable access to Azure AKS and ACR from within your Hopsworks cluster. Defaults to `false`.
 - **enable_backup** (Boolean) Add permissions required to allow creating backups of your clusters. Defaults to `true`.
 - **enable_storage** (Boolean) Add permissions required to allow Hopsworks clusters to read and write from and to your azure storage accounts. Defaults to `true`.
-- **enable_upgrade** (Boolean) Add permissions required to enable upgrade to newer versions of Hopsworks. Defaults to `false`.
+- **enable_upgrade** (Boolean, Deprecated) Add permissions required to enable upgrade to newer versions of Hopsworks. Defaults to `false`. These permissions are not required anymore to upgrade from version 2.4.0 and onwards.
 - **id** (String) The ID of this resource.
 
 ### Read-Only

--- a/hopsworksai/data_source_aws_instance_profile_policy.go
+++ b/hopsworksai/data_source_aws_instance_profile_policy.go
@@ -53,7 +53,8 @@ func dataSourceAWSInstanceProfilePolicy() *schema.Resource {
 				Description: "Add permissions required to enable upgrade to newer versions of Hopsworks.",
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Default:     false,
+				Deprecated:  "These permissions are not required anymore to upgrade from version 2.4.0 and onwards.",
 			},
 			"enable_eks_and_ecr": {
 				Description: "Add permissions required to enable access to Amazon EKS and ECR from within your Hopsworks cluster.",

--- a/hopsworksai/data_source_azure_user_assigned_identity_permissions.go
+++ b/hopsworksai/data_source_azure_user_assigned_identity_permissions.go
@@ -30,6 +30,7 @@ func dataSourceAzureUserAssignedIdentityPermissions() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
+				Deprecated:  "These permissions are not required anymore to upgrade from version 2.4.0 and onwards.",
 			},
 			"enable_aks_and_acr": {
 				Description: "Add permissions required to enable access to Azure AKS and ACR from within your Hopsworks cluster.",


### PR DESCRIPTION


## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
  - [x] Adds tests for the submitted changes (for bug fixes & features)
  - [ ] Passes the tests including acceptance test
  - [x] An issue has been opened for this PR
  - [x] Updates the change log
  - [x] All commits have been squashed down to a single commit


* **Close the associated issue**
  
Closes https://github.com/logicalclocks/terraform-provider-hopsworksai/issues/79
 