### PR TITLE
Use r5 and c5 instance types in RonDB upscale acceptance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ BUG FIXES:
 ENHANCEMENTS:
 acceptance_tests: Tag resources with their respective test name
 acceptance_tests: Providers is deprecated use ProviderFactories instead
+acceptance_tests: Use r5 and c5 instance types in RonDB upscale tests
 
 FEATURES:
 

--- a/hopsworksai/resource_cluster_test.go
+++ b/hopsworksai/resource_cluster_test.go
@@ -663,7 +663,7 @@ func testAccCluster_Head_upscale(t *testing.T, cloud api.CloudProvider, currentI
 }
 
 func TestAccClusterAWS_RonDB_upscale(t *testing.T) {
-	testAccCluster_RonDB_upscale(t, api.AWS, "t3a.xlarge", "t3a.2xlarge", "t3a.medium", "t3a.large", "t3a.medium", "t3a.large")
+	testAccCluster_RonDB_upscale(t, api.AWS, "r5.large", "r5.xlarge", "c5.large", "c5.xlarge", "c5.large", "c5.xlarge")
 }
 
 func TestAccClusterAZURE_RonDB_upscale(t *testing.T) {


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
  - [ ] Adds tests for the submitted changes (for bug fixes & features)
  - [ ] Passes the tests including acceptance test
  - [x] An issue has been opened for this PR
  - [x] Updates the change log
  - [x] All commits have been squashed down to a single commit


* **Close the associated issue**
  
  Closes https://github.com/logicalclocks/terraform-provider-hopsworksai/issues/114
