### PR TITLE
Change ssh_key attribute to be optional for AWS clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ ENHANCEMENTS:
 * resource/hopsworksai_cluster: Add `cluster_domain_prefix` attribute to override the default UUID name of a Cluster. This option is available **only** to users with special privileges.
 * resource/hopsworksai_cluster: Add `custom_hosted_zone` attribute to override the default Hosted Zone of a cluster's public domain name (cloud.hopsworks.ai). This option is available **only** to users with special privileges.
 * resource/hopsworksai_cluster: Add `aws_attributes/ebs_encryption` attribute to configure EBS encryption for disks on AWS clusters.
+* resource/hopsworksai_cluster: Change `ssh_key` attribute to be optional for AWS.
 
 BUG FIXES:
 * datasource/aws_instance_profile_policy: The `ecr:CreateRepository` permission has no resource level condition for private registries

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -82,7 +82,6 @@ resource "hopsworksai_cluster" "cluster" {
 
 - `head` (Block List, Min: 1, Max: 1) The configurations of the head node of the cluster. (see [below for nested schema](#nestedblock--head))
 - `name` (String) The name of the cluster, must be unique.
-- `ssh_key` (String) The ssh key name that will be attached to this cluster.
 
 ### Optional
 
@@ -102,6 +101,7 @@ resource "hopsworksai_cluster" "cluster" {
 - `os` (String) The operating system to use for the instances. Supported systems are ubuntu in all regions and centos in some specific regions Defaults to `ubuntu`.
 - `rondb` (Block List, Max: 1) Setup a cluster with managed RonDB. (see [below for nested schema](#nestedblock--rondb))
 - `run_init_script_first` (Boolean) Run the init script before any other node initialization. WARNING if your initscript interfere with the following node initialization the cluster may not start properly. Make sure that you know what you are doing.
+- `ssh_key` (String) The ssh key name that will be attached to this cluster.
 - `tags` (Map of String) The list of custom tags to be attached to the cluster.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `update_state` (String) The action you can use to start or stop the cluster. Defaults to `none`.

--- a/hopsworksai/resource_cluster_test.go
+++ b/hopsworksai/resource_cluster_test.go
@@ -1472,6 +1472,7 @@ func TestClusterCreate_error(t *testing.T) {
 					"disk_size": 512,
 				},
 			},
+			"ssh_key": "my-key",
 			"azure_attributes": []interface{}{
 				map[string]interface{}{
 					"location":                       "location-1",
@@ -1567,6 +1568,7 @@ func TestClusterCreate_AzureDefaultInstanceType(t *testing.T) {
 					"disk_size": 512,
 				},
 			},
+			"ssh_key": "my-key",
 			"azure_attributes": []interface{}{
 				map[string]interface{}{
 					"location":                       "location-1",
@@ -2136,6 +2138,7 @@ func testClusterCreate_RonDB(t *testing.T, cloud api.CloudProvider) {
 				"disk_size": 512,
 			},
 		},
+		"ssh_key": "my-key",
 		"workers": []interface{}{
 			map[string]interface{}{
 				"disk_size": 256,
@@ -2306,7 +2309,8 @@ func testGetRonDBConfig(reqBody io.Reader, cloud api.CloudProvider) (*api.RonDBC
 
 func testClusterCreate_RonDB_default(t *testing.T, cloud api.CloudProvider) {
 	state := map[string]interface{}{
-		"name": "cluster",
+		"name":    "cluster",
+		"ssh_key": "my-key",
 		"head": []interface{}{
 			map[string]interface{}{
 				"disk_size": 512,
@@ -2382,6 +2386,7 @@ func testClusterCreate_RonDB_defaultEmptyBlocks(t *testing.T, cloud api.CloudPro
 				"disk_size": 512,
 			},
 		},
+		"ssh_key": "my-key",
 		"workers": []interface{}{
 			map[string]interface{}{
 				"disk_size": 256,
@@ -2479,6 +2484,7 @@ func testClusterCreate_RonDB_invalidReplicationFactor(t *testing.T, cloud api.Cl
 				"disk_size": 512,
 			},
 		},
+		"ssh_key": "my-key",
 		"workers": []interface{}{
 			map[string]interface{}{
 				"disk_size": 256,
@@ -2548,6 +2554,7 @@ func testClusterCreate_Autoscale(t *testing.T, cloud api.CloudProvider, withGpu 
 				"disk_size": 512,
 			},
 		},
+		"ssh_key": "my-key",
 		"autoscale": []interface{}{
 			map[string]interface{}{
 				"non_gpu_workers": []interface{}{
@@ -3162,6 +3169,7 @@ func TestClusterCreate_AZURE_container(t *testing.T) {
 					"disk_size": 512,
 				},
 			},
+			"ssh_key": "my-key",
 			"azure_attributes": []interface{}{
 				map[string]interface{}{
 					"location":                       "location-1",
@@ -3209,6 +3217,7 @@ func TestClusterCreate_AZURE_searchDomain_deprecated(t *testing.T) {
 					"disk_size": 512,
 				},
 			},
+			"ssh_key": "my-key",
 			"azure_attributes": []interface{}{
 				map[string]interface{}{
 					"location":                       "location-1",
@@ -3256,6 +3265,7 @@ func TestClusterCreate_AZURE_searchDomain(t *testing.T) {
 					"disk_size": 512,
 				},
 			},
+			"ssh_key": "my-key",
 			"azure_attributes": []interface{}{
 				map[string]interface{}{
 					"location":                       "location-1",
@@ -3307,6 +3317,7 @@ func TestClusterCreate_AZURE_ASK_cluster(t *testing.T) {
 					"disk_size": 512,
 				},
 			},
+			"ssh_key": "my-key",
 			"azure_attributes": []interface{}{
 				map[string]interface{}{
 					"location":                       "location-1",
@@ -4430,6 +4441,7 @@ func TestClusterCreate_AZURE_setEncryption(t *testing.T) {
 					"disk_size":     512,
 				},
 			},
+			"ssh_key": "my-key",
 			"azure_attributes": []interface{}{
 				map[string]interface{}{
 					"location":                       "location-1",
@@ -4494,6 +4506,7 @@ func TestClusterCreate_AZURE_setEncryption_default(t *testing.T) {
 					"disk_size":     512,
 				},
 			},
+			"ssh_key": "my-key",
 			"azure_attributes": []interface{}{
 				map[string]interface{}{
 					"location":                       "location-1",
@@ -4547,6 +4560,7 @@ func TestClusterCreate_AZURE_newContainerConfiguration(t *testing.T) {
 					"disk_size":     512,
 				},
 			},
+			"ssh_key": "my-key",
 			"azure_attributes": []interface{}{
 				map[string]interface{}{
 					"location":                       "location-1",
@@ -4579,6 +4593,7 @@ func TestClusterCreate_AZURE_error_noStorageAccountConfigured(t *testing.T) {
 					"disk_size":     512,
 				},
 			},
+			"ssh_key": "my-key",
 			"azure_attributes": []interface{}{
 				map[string]interface{}{
 					"location":                       "location-1",


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
  - [ ] Adds tests for the submitted changes (for bug fixes & features)
  - [ ] Passes the tests including acceptance test
  - [x] An issue has been opened for this PR
  - [x] Updates the change log
  - [x] All commits have been squashed down to a single commit


* **Close the associated issue**
  
  Closes https://github.com/logicalclocks/terraform-provider-hopsworksai/issues/73