### PR TITLE
[CLOUD-737] Make Hopsworks 3.8.0 the default deployable version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ NOTES:
 BREAKING CHANGES:
 
 ENHANCEMENTS:
+* resource/hopsworksai_cluster: Set Default `version` to 3.8.0
 
 FEATURES:
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -125,7 +125,7 @@ resource "hopsworksai_cluster" "cluster" {
 - `tags` (Map of String) The list of custom tags to be attached to the cluster.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `update_state` (String) The action you can use to start or stop the cluster. It has to be one of these values [none, start, stop]. Defaults to `none`.
-- `version` (String) The version of the cluster. For existing clusters, you can change this attribute to upgrade to a newer version of Hopsworks. If the upgrade process ended up in an error state, you can always rollback to the old version by resetting this attribute to the old version. Defaults to `3.7.1`.
+- `version` (String) The version of the cluster. For existing clusters, you can change this attribute to upgrade to a newer version of Hopsworks. If the upgrade process ended up in an error state, you can always rollback to the old version by resetting this attribute to the old version. Defaults to `3.8.0`.
 - `workers` (Block Set) The configurations of worker nodes. You can add as many as you want of this block to create workers with different configurations. (see [below for nested schema](#nestedblock--workers))
 
 ### Read-Only

--- a/hopsworksai/resource_cluster.go
+++ b/hopsworksai/resource_cluster.go
@@ -116,7 +116,7 @@ func clusterSchema() map[string]*schema.Schema {
 			Description: "The version of the cluster. For existing clusters, you can change this attribute to upgrade to a newer version of Hopsworks. If the upgrade process ended up in an error state, you can always rollback to the old version by resetting this attribute to the old version.",
 			Type:        schema.TypeString,
 			Optional:    true,
-			Default:     "3.7.1",
+			Default:     "3.8.0",
 		},
 		"head": {
 			Description: "The configurations of the head node of the cluster.",


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

https://hopsworks.atlassian.net/browse/CLOUD-737

* **Please check if the PR meets the following requirements**
  - [ ] Adds tests for the submitted changes (for bug fixes & features)
  - [ ] Passes the tests including acceptance test
  - [ ] An issue has been opened for this PR
  - [x] Updates the change log
  - [x] All commits have been squashed down to a single commit


* **Close the associated issue**
  
  Closes #0000
  
  Relates #0000
